### PR TITLE
fix: fix key generation for documents with array of non-object values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deeks",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Retrieve all keys and nested keys from objects and arrays of objects.",
   "main": "src/deeks.js",
   "scripts": {

--- a/src/deeks.js
+++ b/src/deeks.js
@@ -44,14 +44,25 @@ function generateDeepKeysList(heading, data) {
             return generateDeepKeysList(keyName, data[currentKey]);
         } else if (isArrayToRecurOn(data[currentKey])) {
             // If we have a nested array that we need to recur on
-            return _.flatten(deepKeysFromList(data[currentKey]))
-                .map((subKey) => buildKeyName(keyName, subKey));
+            return processArrayKeys(data[currentKey], currentKey);
         }
         // Otherwise return this key name since we don't have a sub document
         return keyName;
     });
 
     return _.flatten(keys);
+}
+
+function processArrayKeys(subArray, currentKeyPath) {
+    let subArrayKeys = deepKeysFromList(subArray)
+        .map((schemaKeys) => {
+            if (isEmptyArray(schemaKeys)) {
+                return [currentKeyPath];
+            }
+            return schemaKeys.map((subKey) => buildKeyName(currentKeyPath, subKey));
+        });
+
+    return _.uniq(_.flatten(subArrayKeys));
 }
 
 /**
@@ -83,4 +94,13 @@ function isDocumentToRecurOn(val) {
  */
 function isArrayToRecurOn(val) {
     return _.isArray(val) && val.length;
+}
+
+/**
+ * Helper function that determines whether or not a value is an empty array
+ * @param val
+ * @returns {boolean}
+ */
+function isEmptyArray(val) {
+    return Array.isArray(val) && !val.length;
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -272,7 +272,28 @@ describe('deeks Module', () => {
                 keys = deeks.deepKeysFromList(testList);
 
             keys.should.be.an.instanceOf(Array)
-                .and.containEql(['make', 'model', 'trim', 'specifications.odometer.miles', 'specifications.odometer.km', 'specifications.cylinders'])
+                .and.containEql(['make', 'model', 'trim', 'specifications.odometer.miles', 'specifications.odometer.km', 'specifications.cylinders', 'specifications'])
+                .and.have.lengthOf(1);
+            done();
+        });
+
+        it('should return the key name for the field with an array value if it contains a non-document value', function (done) {
+            let testList = [
+                    {
+                        make: 'Nissan',
+                        model: 'GT-R',
+                        trim: 'NISMO',
+                        rebates: [
+                            500,
+                            500,
+                            1500
+                        ]
+                    }
+                ],
+                keys = deeks.deepKeysFromList(testList);
+
+            keys.should.be.an.instanceOf(Array)
+                .and.containEql(['make', 'model', 'trim', 'rebates'])
                 .and.have.lengthOf(1);
             done();
         });

--- a/test/tests.js
+++ b/test/tests.js
@@ -277,7 +277,7 @@ describe('deeks Module', () => {
             done();
         });
 
-        it('should return the key name for the field with an array value if it contains a non-document value', function (done) {
+        it('should return the key name for the field with an array value if it contains a non-document value', (done) => {
             let testList = [
                     {
                         make: 'Nissan',


### PR DESCRIPTION
* Fixes an issue where the generated key list did not include the key path for fields with an array of non JS objects as their value.

Fixes #2 

Release: 2.0.1