### PR TITLE
feat: add expandArrayObjects option to allow for array key expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,30 +21,62 @@ npm install --save deeks
 
 Example: 
 ```javascript
-let keys = require('deeks');
+let keys = require('deeks'),
+	docPath = require('doc-path');
 
-keys.deepKeys({
+let generatedKeys = keys.deepKeys({
 	make: 'Nissan',
 	model: 'GT-R',
 	trim: 'NISMO',
-	specifications: {
-	    mileage: 10,
-	    cylinders: '6'
-	}
-})
+	specifications: [
+	    {mileage: 10},
+	    {cylinders: 6}
+	]
+}, {expandArrayObjects: true});
 // => ['make', 'model', 'trim', 'specifications.mileage', 'specifications.cylinders']
+
+generatedKeys.forEach((key) => 
+    console.log(
+        docPath.evaluatePath(key)
+	)
+)
+// Console Output:
+// Nissan
+// GT-R
+// NISMO
+// 10
+// 6
 ```
 
 ## API
 
 ### deepKeys(object) 
 
-`keys.deepKeys(object)`
+`keys.deepKeys(object, options)`
 
 Returns all keys in an object, even if they're nested several layers deep. 
 The array of keys that is returned can then be used with the 
 [`doc-path`](https://github.com/mrodrig/doc-path) module to get and set values 
 at a specific key path.
+
+Options (optional):
+- expandArrayObjects - `Boolean` (Default: `false`) - Should objects appearing in arrays in the provided 
+object also be expanded, such that keys appearing in those objects are extracted and 
+included in the returned key path list?
+	- Example:
+	```json
+	{
+		"make": "Nissan",
+		"model": "GT-R",
+		"trim": "NISMO",
+		"specifications": [
+			{"mileage": 10},
+			{"cylinders": 6}
+		]
+	}
+	```
+	- expandArrayObjects = `false` results in: `['make', 'model', 'trim', 'specifications']`
+	- expandArrayObjects = `true` results in: `['make', 'model', 'trim', 'specifications.mileage', 'specifications.cylinders']`
 
 Returns: `Array[String]`
 
@@ -57,6 +89,25 @@ Example: `['make', 'model', 'specifications.odometer.miles', 'specifications.odo
 Returns all keys in each object in the array, even if the keys are nested 
 several layers deep in each of the documents. These can also be used with the 
 [`doc-path`](https://github.com/mrodrig/doc-path) module.
+
+Options (optional):
+- expandArrayObjects - `Boolean` (Default: `false`) - Should objects appearing in arrays in the provided 
+object also be expanded, such that keys appearing in those objects are extracted and 
+included in the returned key path list?
+	- Example:
+	```json
+	{
+		"make": "Nissan",
+		"model": "GT-R",
+		"trim": "NISMO",
+		"specifications": [
+			{"mileage": 10},
+			{"cylinders": 6}
+		]
+	}
+	```
+	- expandArrayObjects = `false` results in: `['make', 'model', 'trim', 'specifications']`
+	- expandArrayObjects = `true` results in: `['make', 'model', 'trim', 'specifications.mileage', 'specifications.cylinders']`
 
 Returns: `Array[Array[String]]`
 

--- a/src/deeks.js
+++ b/src/deeks.js
@@ -12,9 +12,10 @@ module.exports = {
  * @param object
  * @returns {Array}
  */
-function deepKeys(object) {
+function deepKeys(object, options) {
+    options = mergeOptions(options);
     if (_.isObject(object)) {
-        return generateDeepKeysList('', object);
+        return generateDeepKeysList('', object, options);
     }
     return [];
 }
@@ -24,25 +25,26 @@ function deepKeys(object) {
  * @param list
  * @returns Array[Array[String]]
  */
-function deepKeysFromList(list) {
+function deepKeysFromList(list, options) {
+    options = mergeOptions(options);
     return list.map((document) => { // for each document
         if (_.isObject(document)) {
             // if the data at the key is a document, then we retrieve the subHeading starting with an empty string heading and the doc
-            return deepKeys(document);
+            return deepKeys(document, options);
         }
         return [];
     });
 }
 
-function generateDeepKeysList(heading, data) {
+function generateDeepKeysList(heading, data, options) {
     let keys = Object.keys(data).map((currentKey) => {
         // If the given heading is empty, then we set the heading to be the subKey, otherwise set it as a nested heading w/ a dot
         let keyName = buildKeyName(heading, currentKey);
 
         // If we have another nested document, recur on the sub-document to retrieve the full key name
         if (isDocumentToRecurOn(data[currentKey])) {
-            return generateDeepKeysList(keyName, data[currentKey]);
-        } else if (isArrayToRecurOn(data[currentKey])) {
+            return generateDeepKeysList(keyName, data[currentKey], options);
+        } else if (options.expandArrayObjects && isArrayToRecurOn(data[currentKey])) {
             // If we have a nested array that we need to recur on
             return processArrayKeys(data[currentKey], currentKey);
         }
@@ -103,4 +105,10 @@ function isArrayToRecurOn(val) {
  */
 function isEmptyArray(val) {
     return Array.isArray(val) && !val.length;
+}
+
+function mergeOptions(options) {
+    return _.defaults(options || {}, {
+        expandArrayObjects: false
+    });
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -106,6 +106,30 @@ describe('deeks Module', () => {
                 .and.containEql('make')
                 .and.containEql('model')
                 .and.containEql('trim')
+                .and.containEql('specifications')
+                .and.have.lengthOf(4);
+            done();
+        });
+
+        it('should retrieve the keys for objects containing an array of sub-objects (with expandArrayObjects = true)', (done) => {
+            let testObj = {
+                    make: 'Nissan',
+                    model: 'GT-R',
+                    trim: 'NISMO',
+                    specifications: [
+                        { mileage: 10 },
+                        { cylinders: '6' }
+                    ]
+                },
+                options = {
+                    expandArrayObjects: true
+                },
+                keys = deeks.deepKeys(testObj, options);
+
+            keys.should.be.an.instanceOf(Array)
+                .and.containEql('make')
+                .and.containEql('model')
+                .and.containEql('trim')
                 .and.containEql('specifications.mileage')
                 .and.containEql('specifications.cylinders')
                 .and.have.lengthOf(5);
@@ -169,7 +193,7 @@ describe('deeks Module', () => {
             done();
         });
 
-        it('should retrieve no keys for an array of one object with multiple single-level keys', (done) => {
+        it('should retrieve keys for an array of one object with multiple single-level keys', (done) => {
             let testList = [
                     {
                         a: 1,
@@ -184,7 +208,7 @@ describe('deeks Module', () => {
             done();
         });
 
-        it('should retrieve no keys for an array of one object with multi-level keys', (done) => {
+        it('should retrieve keys for an array of one object with multi-level keys', (done) => {
             let testList = [
                     {
                         a: 1,
@@ -203,7 +227,7 @@ describe('deeks Module', () => {
             done();
         });
 
-        it('should retrieve no keys for an array of one object with multi-level keys', (done) => {
+        it('should retrieve keys for an array of two objects with multi-level keys', (done) => {
             let testList = [
                     {
                         a: 1,
@@ -246,7 +270,7 @@ describe('deeks Module', () => {
                 keys = deeks.deepKeysFromList(testList);
 
             keys.should.be.an.instanceOf(Array)
-                .and.containEql(['make', 'model', 'trim', 'specifications.mileage', 'specifications.cylinders'])
+                .and.containEql(['make', 'model', 'trim', 'specifications'])
                 .and.have.lengthOf(1);
             done();
         });
@@ -272,7 +296,7 @@ describe('deeks Module', () => {
                 keys = deeks.deepKeysFromList(testList);
 
             keys.should.be.an.instanceOf(Array)
-                .and.containEql(['make', 'model', 'trim', 'specifications.odometer.miles', 'specifications.odometer.km', 'specifications.cylinders', 'specifications'])
+                .and.containEql(['make', 'model', 'trim', 'specifications'])
                 .and.have.lengthOf(1);
             done();
         });
@@ -294,6 +318,58 @@ describe('deeks Module', () => {
 
             keys.should.be.an.instanceOf(Array)
                 .and.containEql(['make', 'model', 'trim', 'rebates'])
+                .and.have.lengthOf(1);
+            done();
+        });
+
+        it('should retrieve keys for an array of one object with array of objects (with expandArrayObjects = true)', (done) => {
+            let testList = [
+                    {
+                        make: 'Nissan',
+                        model: 'GT-R',
+                        trim: 'NISMO',
+                        specifications: [
+                            { mileage: 10 },
+                            { cylinders: '6' }
+                        ]
+                    }
+                ],
+                options = {
+                    expandArrayObjects: true
+                },
+                keys = deeks.deepKeysFromList(testList, options);
+
+            keys.should.be.an.instanceOf(Array)
+                .and.containEql(['make', 'model', 'trim', 'specifications.mileage', 'specifications.cylinders'])
+                .and.have.lengthOf(1);
+            done();
+        });
+
+        it('should retrieve keys for an array of one object with array of multi-level objects, with a non-object (with expandArrayObjects = true)', (done) => {
+            let testList = [
+                    {
+                        make: 'Nissan',
+                        model: 'GT-R',
+                        trim: 'NISMO',
+                        specifications: [
+                            {
+                                odometer: {
+                                    miles: 10,
+                                    km: 22
+                                }
+                            },
+                            { cylinders: '6' },
+                            5
+                        ]
+                    }
+                ],
+                options = {
+                    expandArrayObjects: true
+                },
+                keys = deeks.deepKeysFromList(testList, options);
+
+            keys.should.be.an.instanceOf(Array)
+                .and.containEql(['make', 'model', 'trim', 'specifications.odometer.miles', 'specifications.odometer.km', 'specifications.cylinders', 'specifications'])
                 .and.have.lengthOf(1);
             done();
         });


### PR DESCRIPTION
* Provides an option to explore and generate keys for objects appearing in arrays, or when false, the original behavior of ignoring keys appearing in objects inside an array value.

Release: 2.1.0