### PR TITLE
fix: remove redundant key from generated key list

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ let generatedKeys = keys.deepKeys({
 	    {mileage: 10},
 	    {cylinders: 6}
 	]
-}, {expandArrayObjects: true});
+}, {
+    expandArrayObjects: true,
+    ignoreEmptyArraysWhenExpanding: true
+});
 // => ['make', 'model', 'trim', 'specifications.mileage', 'specifications.cylinders']
 
 generatedKeys.forEach((key) => 
@@ -77,6 +80,17 @@ included in the returned key path list?
 	```
 	- expandArrayObjects = `false` results in: `['make', 'model', 'trim', 'specifications']`
 	- expandArrayObjects = `true` results in: `['make', 'model', 'trim', 'specifications.mileage', 'specifications.cylinders']`
+- ignoreEmptyArraysWhenExpanding - `Boolean` (Default: `false`) - Should empty array keys be ignored when expanding array objects?
+	- Note: This only has an effect when used with `expandArrayObjects`.
+	- Example:
+	```json
+	{ 
+		"features": [ {"name": "A/C" }],
+		"rebates": []
+	}
+	```
+	- ignoreEmptyArraysWhenExpanding = `false` results in: `['features.name', 'rebates']`
+	- ignoreEmptyArraysWhenExpanding = `true` results in: `['features.name']`
 
 Returns: `Array[String]`
 
@@ -108,6 +122,17 @@ included in the returned key path list?
 	```
 	- expandArrayObjects = `false` results in: `['make', 'model', 'trim', 'specifications']`
 	- expandArrayObjects = `true` results in: `['make', 'model', 'trim', 'specifications.mileage', 'specifications.cylinders']`
+- ignoreEmptyArraysWhenExpanding - `Boolean` (Default: `false`) - Should empty array keys be ignored when expanding array objects?
+	- Note: This only has an effect when used with `expandArrayObjects`.
+	- Example:
+	```json
+	[
+		{ "features": [ {"name": "A/C" }] },
+		{ "features": [] }
+	] 
+	```
+	- ignoreEmptyArraysWhenExpanding = `false` results in: `['features.name', 'features']`
+	- ignoreEmptyArraysWhenExpanding = `true` results in: `['features.name']`
 
 Returns: `Array[Array[String]]`
 
@@ -158,8 +183,8 @@ $ npm run coverage
 
 Current Coverage is:
 ```
-Statements   : 100% ( 41/41 )
-Branches     : 100% ( 24/24 )
+Statements   : 100% ( 46/46 )
+Branches     : 100% ( 30/30 )
 Functions    : 100% ( 9/9 )
-Lines        : 100% ( 40/40 )
+Lines        : 100% ( 45/45 )
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "deeks",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "deeks",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deeks",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Retrieve all keys and nested keys from objects and arrays of objects.",
   "main": "src/deeks.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "url": "git+https://github.com/mrodrig/deeks.git"
   },
   "keywords": [
+    "get",
     "keys",
     "object",
+    "document",
     "deep",
     "deeks",
     "recursive"

--- a/src/deeks.js
+++ b/src/deeks.js
@@ -10,6 +10,7 @@ module.exports = {
 /**
  * Return the deep keys list for a single document
  * @param object
+ * @param options
  * @returns {Array}
  */
 function deepKeys(object, options) {
@@ -23,6 +24,7 @@ function deepKeys(object, options) {
 /**
  * Return the deep keys list for all documents in the provided list
  * @param list
+ * @param options
  * @returns Array[Array[String]]
  */
 function deepKeysFromList(list, options) {
@@ -55,16 +57,31 @@ function generateDeepKeysList(heading, data, options) {
     return _.flatten(keys);
 }
 
+/**
+ * Helper function to handle the processing of arrays when the expandArrayObjects
+ * option is specified.
+ * @param subArray
+ * @param currentKeyPath
+ * @returns {*}
+ */
 function processArrayKeys(subArray, currentKeyPath) {
-    let subArrayKeys = deepKeysFromList(subArray)
-        .map((schemaKeys) => {
+    let subArrayKeys = deepKeysFromList(subArray);
+
+    if (!subArray.length) {
+        return [];
+    } else if (subArray.length && _.flatten(subArrayKeys).length === 0) {
+        // Has items in the array, but no objects
+        return [currentKeyPath];
+    } else {
+        subArrayKeys = subArrayKeys.map((schemaKeys) => {
             if (isEmptyArray(schemaKeys)) {
                 return [currentKeyPath];
             }
             return schemaKeys.map((subKey) => buildKeyName(currentKeyPath, subKey));
         });
 
-    return _.uniq(_.flatten(subArrayKeys));
+        return _.uniq(_.flatten(subArrayKeys));
+    }
 }
 
 /**
@@ -95,7 +112,7 @@ function isDocumentToRecurOn(val) {
  * @returns {boolean}
  */
 function isArrayToRecurOn(val) {
-    return _.isArray(val) && val.length;
+    return _.isArray(val);
 }
 
 /**

--- a/src/deeks.js
+++ b/src/deeks.js
@@ -48,7 +48,7 @@ function generateDeepKeysList(heading, data, options) {
             return generateDeepKeysList(keyName, data[currentKey], options);
         } else if (options.expandArrayObjects && isArrayToRecurOn(data[currentKey])) {
             // If we have a nested array that we need to recur on
-            return processArrayKeys(data[currentKey], currentKey);
+            return processArrayKeys(data[currentKey], currentKey, options);
         }
         // Otherwise return this key name since we don't have a sub document
         return keyName;
@@ -62,13 +62,14 @@ function generateDeepKeysList(heading, data, options) {
  * option is specified.
  * @param subArray
  * @param currentKeyPath
+ * @param options
  * @returns {*}
  */
-function processArrayKeys(subArray, currentKeyPath) {
+function processArrayKeys(subArray, currentKeyPath, options) {
     let subArrayKeys = deepKeysFromList(subArray);
 
     if (!subArray.length) {
-        return [];
+        return options.ignoreEmptyArraysWhenExpanding ? [] : [currentKeyPath];
     } else if (subArray.length && _.flatten(subArrayKeys).length === 0) {
         // Has items in the array, but no objects
         return [currentKeyPath];
@@ -103,7 +104,7 @@ function buildKeyName(upperKeyName, currentKeyName) {
  * @returns {boolean}
  */
 function isDocumentToRecurOn(val) {
-    return _.isObject(val) && !_.isNull(val) && !_.isArray(val) && Object.keys(val).length;
+    return _.isObject(val) && !_.isNull(val) && !Array.isArray(val) && Object.keys(val).length;
 }
 
 /**
@@ -112,7 +113,7 @@ function isDocumentToRecurOn(val) {
  * @returns {boolean}
  */
 function isArrayToRecurOn(val) {
-    return _.isArray(val);
+    return Array.isArray(val);
 }
 
 /**
@@ -126,6 +127,7 @@ function isEmptyArray(val) {
 
 function mergeOptions(options) {
     return _.defaults(options || {}, {
-        expandArrayObjects: false
+        expandArrayObjects: false,
+        ignoreEmptyArraysWhenExpanding: false
     });
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -5,373 +5,489 @@ const deeks = require('../src/deeks.js'),
     should = require('should');
 
 describe('deeks Module', () => {
-    describe('Objects', () => {
-        it('should retrieve no keys for an empty object', (done) => {
-            let testObj = {},
-                keys = deeks.deepKeys(testObj);
+    describe('deepKeys() - Objects', () => {
+        describe('Default Options', () => {
+            it('should retrieve no keys for an empty object', (done) => {
+                let testObj = {},
+                    keys = deeks.deepKeys(testObj);
 
-            keys.should.be.an.instanceOf(Array)
-                .and.have.lengthOf(0);
-            done();
-        });
+                keys.should.be.an.instanceOf(Array)
+                    .and.have.lengthOf(0);
+                done();
+            });
 
-        it('should retrieve no keys for a non-object', (done) => {
-            let testObj = 'testing',
-                keys = deeks.deepKeys(testObj);
+            it('should retrieve no keys for a non-object', (done) => {
+                let testObj = 'testing',
+                    keys = deeks.deepKeys(testObj);
 
-            keys.should.be.an.instanceOf(Array)
-                .and.have.lengthOf(0);
-            done();
-        });
+                keys.should.be.an.instanceOf(Array)
+                    .and.have.lengthOf(0);
+                done();
+            });
 
-        it('should retrieve the keys for a single keyed object', (done) => {
-            let testObj = { a: 1 },
-                keys = deeks.deepKeys(testObj);
+            it('should retrieve the keys for a single keyed object', (done) => {
+                let testObj = { a: 1 },
+                    keys = deeks.deepKeys(testObj);
 
-            keys.should.be.an.instanceOf(Array)
-                .and.containEql('a')
-                .and.have.lengthOf(1);
-            done();
-        });
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql('a')
+                    .and.have.lengthOf(1);
+                done();
+            });
 
-        it('should retrieve the keys for a multiple keyed object', (done) => {
-            let testObj = {
-                    a: 1,
-                    b: 2
-                },
-                keys = deeks.deepKeys(testObj);
-
-            keys.should.be.an.instanceOf(Array)
-                .and.containEql('a')
-                .and.containEql('b')
-                .and.have.lengthOf(2);
-            done();
-        });
-
-        it('should retrieve the keys for a multi-level object', (done) => {
-            let testObj = {
-                    a: 1,
-                    b: 2,
-                    c: {
-                        d: 4
-                    }
-                },
-                keys = deeks.deepKeys(testObj);
-
-            keys.should.be.an.instanceOf(Array)
-                .and.containEql('a')
-                .and.containEql('b')
-                .and.containEql('c.d')
-                .and.have.lengthOf(3);
-            done();
-        });
-
-        it('should retrieve the keys for a deep multi-level object', (done) => {
-            let testObj = {
-                    a: 1,
-                    b: 2,
-                    c: {
-                        d: {
-                            e: {
-                                f: {
-                                    g: 7
-                                }
-                            }
-                        }
-                    }
-                },
-                keys = deeks.deepKeys(testObj);
-
-            keys.should.be.an.instanceOf(Array)
-                .and.containEql('a')
-                .and.containEql('b')
-                .and.containEql('c.d.e.f.g')
-                .and.have.lengthOf(3);
-            done();
-        });
-
-        it('should retrieve the keys for objects containing an array of sub-objects', (done) => {
-            let testObj = {
-                    make: 'Nissan',
-                    model: 'GT-R',
-                    trim: 'NISMO',
-                    specifications: [
-                        { mileage: 10 },
-                        { cylinders: '6' }
-                    ]
-                },
-                keys = deeks.deepKeys(testObj);
-
-            keys.should.be.an.instanceOf(Array)
-                .and.containEql('make')
-                .and.containEql('model')
-                .and.containEql('trim')
-                .and.containEql('specifications')
-                .and.have.lengthOf(4);
-            done();
-        });
-
-        it('should retrieve the keys for objects containing an array of sub-objects (with expandArrayObjects = true)', (done) => {
-            let testObj = {
-                    make: 'Nissan',
-                    model: 'GT-R',
-                    trim: 'NISMO',
-                    specifications: [
-                        { mileage: 10 },
-                        { cylinders: '6' }
-                    ]
-                },
-                options = {
-                    expandArrayObjects: true
-                },
-                keys = deeks.deepKeys(testObj, options);
-
-            keys.should.be.an.instanceOf(Array)
-                .and.containEql('make')
-                .and.containEql('model')
-                .and.containEql('trim')
-                .and.containEql('specifications.mileage')
-                .and.containEql('specifications.cylinders')
-                .and.have.lengthOf(5);
-            done();
-        });
-    });
-
-    describe('List of Objects', () => {
-        it('should retrieve no keys for an empty array', (done) => {
-            let testList = [],
-                keys = deeks.deepKeysFromList(testList);
-
-            keys.should.be.an.instanceOf(Array)
-                .and.have.lengthOf(0);
-            done();
-        });
-
-        it('should retrieve no keys for an array of a non-object', (done) => {
-            let testList = ['testing'],
-                keys = deeks.deepKeysFromList(testList);
-
-            keys.should.be.an.instanceOf(Array)
-                .and.containEql([])
-                .and.have.lengthOf(1);
-            done();
-        });
-
-        it('should retrieve no keys for an array of one empty object', (done) => {
-            let testList = [{}],
-                keys = deeks.deepKeysFromList(testList);
-
-            keys.should.be.an.instanceOf(Array)
-                .and.containEql([])
-                .and.have.lengthOf(1);
-            done();
-        });
-
-        it('should retrieve keys for an array of one object', (done) => {
-            let testList = [
-                    { a: 1 }
-                ],
-                keys = deeks.deepKeysFromList(testList);
-
-            keys.should.be.an.instanceOf(Array)
-                .and.containEql(['a'])
-                .and.have.lengthOf(1);
-            done();
-        });
-
-        it('should retrieve keys for an array of one object and no keys for a string', (done) => {
-            let testList = [
-                    { a: 1 },
-                    'testing'
-                ],
-                keys = deeks.deepKeysFromList(testList);
-
-            keys.should.be.an.instanceOf(Array)
-                .and.containEql(['a'])
-                .and.containEql([])
-                .and.have.lengthOf(2);
-            done();
-        });
-
-        it('should retrieve keys for an array of one object with multiple single-level keys', (done) => {
-            let testList = [
-                    {
+            it('should retrieve the keys for a multiple keyed object', (done) => {
+                let testObj = {
                         a: 1,
                         b: 2
-                    }
-                ],
-                keys = deeks.deepKeysFromList(testList);
+                    },
+                    keys = deeks.deepKeys(testObj);
 
-            keys.should.be.an.instanceOf(Array)
-                .and.containEql(['a', 'b'])
-                .and.have.lengthOf(1);
-            done();
-        });
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql('a')
+                    .and.containEql('b')
+                    .and.have.lengthOf(2);
+                done();
+            });
 
-        it('should retrieve keys for an array of one object with multi-level keys', (done) => {
-            let testList = [
-                    {
+            it('should retrieve the keys for a multi-level object', (done) => {
+                let testObj = {
                         a: 1,
-                        b: {
-                            c: {
-                                d: 4
-                            }
+                        b: 2,
+                        c: {
+                            d: 4
                         }
-                    }
-                ],
-                keys = deeks.deepKeysFromList(testList);
+                    },
+                    keys = deeks.deepKeys(testObj);
 
-            keys.should.be.an.instanceOf(Array)
-                .and.containEql(['a', 'b.c.d'])
-                .and.have.lengthOf(1);
-            done();
-        });
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql('a')
+                    .and.containEql('b')
+                    .and.containEql('c.d')
+                    .and.have.lengthOf(3);
+                done();
+            });
 
-        it('should retrieve keys for an array of two objects with multi-level keys', (done) => {
-            let testList = [
-                    {
+            it('should retrieve the keys for a deep multi-level object', (done) => {
+                let testObj = {
                         a: 1,
-                        b: {
-                            c: {
-                                d: 4
+                        b: 2,
+                        c: {
+                            d: {
+                                e: {
+                                    f: {
+                                        g: 7
+                                    }
+                                }
                             }
                         }
                     },
-                    {
-                        e: 2,
-                        f: {
-                            g: {
-                                h: 8
+                    keys = deeks.deepKeys(testObj);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql('a')
+                    .and.containEql('b')
+                    .and.containEql('c.d.e.f.g')
+                    .and.have.lengthOf(3);
+                done();
+            });
+
+            it('should retrieve the keys for objects containing an array of sub-objects', (done) => {
+                let testObj = {
+                        make: 'Nissan',
+                        model: 'GT-R',
+                        trim: 'NISMO',
+                        specifications: [
+                            { mileage: 10 },
+                            { cylinders: '6' }
+                        ]
+                    },
+                    keys = deeks.deepKeys(testObj);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql('make')
+                    .and.containEql('model')
+                    .and.containEql('trim')
+                    .and.containEql('specifications')
+                    .and.have.lengthOf(4);
+                done();
+            });
+        });
+
+        describe('Custom Options', () => {
+            it('[expandArrayObjects] should retrieve the keys for objects containing an empty array', (done) => {
+                let testObj = {
+                        make: 'Nissan',
+                        model: 'GT-R',
+                        trim: 'NISMO',
+                        specifications: []
+                    },
+                    options = {
+                        expandArrayObjects: true
+                    },
+                    keys = deeks.deepKeys(testObj, options);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql('make')
+                    .and.containEql('model')
+                    .and.containEql('trim')
+                    .and.have.lengthOf(3);
+                done();
+            });
+
+            it('[expandArrayObjects] should retrieve the keys for objects containing an array of non-objects', (done) => {
+                let testObj = {
+                        make: 'Nissan',
+                        model: 'GT-R',
+                        trim: 'NISMO',
+                        features: ['Insane horsepower', 'Fast acceleration']
+                    },
+                    options = {
+                        expandArrayObjects: true
+                    },
+                    keys = deeks.deepKeys(testObj, options);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql('make')
+                    .and.containEql('model')
+                    .and.containEql('trim')
+                    .and.containEql('features')
+                    .and.have.lengthOf(4);
+                done();
+            });
+
+            it('[expandArrayObjects] should retrieve the keys for objects containing an array of sub-objects', (done) => {
+                let testObj = {
+                        make: 'Nissan',
+                        model: 'GT-R',
+                        trim: 'NISMO',
+                        specifications: [
+                            { mileage: 10 },
+                            { cylinders: '6' }
+                        ]
+                    },
+                    options = {
+                        expandArrayObjects: true
+                    },
+                    keys = deeks.deepKeys(testObj, options);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql('make')
+                    .and.containEql('model')
+                    .and.containEql('trim')
+                    .and.containEql('specifications.mileage')
+                    .and.containEql('specifications.cylinders')
+                    .and.have.lengthOf(5);
+                done();
+            });
+
+            it('[expandArrayObjects] should retrieve the keys for objects containing an array of sub-objects and a non-object', (done) => {
+                let testObj = {
+                        make: 'Nissan',
+                        model: 'GT-R',
+                        trim: 'NISMO',
+                        specifications: [
+                            { mileage: 10 },
+                            { cylinders: '6' },
+                            5
+                        ]
+                    },
+                    options = {
+                        expandArrayObjects: true
+                    },
+                    keys = deeks.deepKeys(testObj, options);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql('make')
+                    .and.containEql('model')
+                    .and.containEql('trim')
+                    .and.containEql('specifications.mileage')
+                    .and.containEql('specifications.cylinders')
+                    .and.containEql('specifications')
+                    .and.have.lengthOf(6);
+                done();
+            });
+        });
+    });
+
+    describe('deepKeysFromList() - List of Objects', () => {
+        describe('Default Options', () => {
+            it('should retrieve no keys for an empty array', (done) => {
+                let testList = [],
+                    keys = deeks.deepKeysFromList(testList);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.have.lengthOf(0);
+                done();
+            });
+
+            it('should retrieve no keys for an array of a non-object', (done) => {
+                let testList = ['testing'],
+                    keys = deeks.deepKeysFromList(testList);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql([])
+                    .and.have.lengthOf(1);
+                done();
+            });
+
+            it('should retrieve no keys for an array of one empty object', (done) => {
+                let testList = [{}],
+                    keys = deeks.deepKeysFromList(testList);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql([])
+                    .and.have.lengthOf(1);
+                done();
+            });
+
+            it('should retrieve keys for an array of one object', (done) => {
+                let testList = [
+                        { a: 1 }
+                    ],
+                    keys = deeks.deepKeysFromList(testList);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql(['a'])
+                    .and.have.lengthOf(1);
+                done();
+            });
+
+            it('should retrieve keys for an array of one object and no keys for a string', (done) => {
+                let testList = [
+                        { a: 1 },
+                        'testing'
+                    ],
+                    keys = deeks.deepKeysFromList(testList);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql(['a'])
+                    .and.containEql([])
+                    .and.have.lengthOf(2);
+                done();
+            });
+
+            it('should retrieve keys for an array of one object with multiple single-level keys', (done) => {
+                let testList = [
+                        {
+                            a: 1,
+                            b: 2
+                        }
+                    ],
+                    keys = deeks.deepKeysFromList(testList);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql(['a', 'b'])
+                    .and.have.lengthOf(1);
+                done();
+            });
+
+            it('should retrieve keys for an array of one object with multi-level keys', (done) => {
+                let testList = [
+                        {
+                            a: 1,
+                            b: {
+                                c: {
+                                    d: 4
+                                }
                             }
                         }
-                    }
-                ],
-                keys = deeks.deepKeysFromList(testList);
+                    ],
+                    keys = deeks.deepKeysFromList(testList);
 
-            keys.should.be.an.instanceOf(Array)
-                .and.containEql(['a', 'b.c.d'])
-                .and.containEql(['e', 'f.g.h'])
-                .and.have.lengthOf(2);
-            done();
-        });
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql(['a', 'b.c.d'])
+                    .and.have.lengthOf(1);
+                done();
+            });
 
-        it('should retrieve keys for an array of one object with array of objects', (done) => {
-            let testList = [
-                    {
-                        make: 'Nissan',
-                        model: 'GT-R',
-                        trim: 'NISMO',
-                        specifications: [
-                            { mileage: 10 },
-                            { cylinders: '6' }
-                        ]
-                    }
-                ],
-                keys = deeks.deepKeysFromList(testList);
-
-            keys.should.be.an.instanceOf(Array)
-                .and.containEql(['make', 'model', 'trim', 'specifications'])
-                .and.have.lengthOf(1);
-            done();
-        });
-
-        it('should retrieve keys for an array of one object with array of multi-level objects, with a non-object', (done) => {
-            let testList = [
-                    {
-                        make: 'Nissan',
-                        model: 'GT-R',
-                        trim: 'NISMO',
-                        specifications: [
-                            {
-                                odometer: {
-                                    miles: 10,
-                                    km: 22
+            it('should retrieve keys for an array of two objects with multi-level keys', (done) => {
+                let testList = [
+                        {
+                            a: 1,
+                            b: {
+                                c: {
+                                    d: 4
                                 }
-                            },
-                            { cylinders: '6' },
-                            5
-                        ]
-                    }
-                ],
-                keys = deeks.deepKeysFromList(testList);
-
-            keys.should.be.an.instanceOf(Array)
-                .and.containEql(['make', 'model', 'trim', 'specifications'])
-                .and.have.lengthOf(1);
-            done();
-        });
-
-        it('should return the key name for the field with an array value if it contains a non-document value', (done) => {
-            let testList = [
-                    {
-                        make: 'Nissan',
-                        model: 'GT-R',
-                        trim: 'NISMO',
-                        rebates: [
-                            500,
-                            500,
-                            1500
-                        ]
-                    }
-                ],
-                keys = deeks.deepKeysFromList(testList);
-
-            keys.should.be.an.instanceOf(Array)
-                .and.containEql(['make', 'model', 'trim', 'rebates'])
-                .and.have.lengthOf(1);
-            done();
-        });
-
-        it('should retrieve keys for an array of one object with array of objects (with expandArrayObjects = true)', (done) => {
-            let testList = [
-                    {
-                        make: 'Nissan',
-                        model: 'GT-R',
-                        trim: 'NISMO',
-                        specifications: [
-                            { mileage: 10 },
-                            { cylinders: '6' }
-                        ]
-                    }
-                ],
-                options = {
-                    expandArrayObjects: true
-                },
-                keys = deeks.deepKeysFromList(testList, options);
-
-            keys.should.be.an.instanceOf(Array)
-                .and.containEql(['make', 'model', 'trim', 'specifications.mileage', 'specifications.cylinders'])
-                .and.have.lengthOf(1);
-            done();
-        });
-
-        it('should retrieve keys for an array of one object with array of multi-level objects, with a non-object (with expandArrayObjects = true)', (done) => {
-            let testList = [
-                    {
-                        make: 'Nissan',
-                        model: 'GT-R',
-                        trim: 'NISMO',
-                        specifications: [
-                            {
-                                odometer: {
-                                    miles: 10,
-                                    km: 22
+                            }
+                        },
+                        {
+                            e: 2,
+                            f: {
+                                g: {
+                                    h: 8
                                 }
-                            },
-                            { cylinders: '6' },
-                            5
-                        ]
-                    }
-                ],
-                options = {
-                    expandArrayObjects: true
-                },
-                keys = deeks.deepKeysFromList(testList, options);
+                            }
+                        }
+                    ],
+                    keys = deeks.deepKeysFromList(testList);
 
-            keys.should.be.an.instanceOf(Array)
-                .and.containEql(['make', 'model', 'trim', 'specifications.odometer.miles', 'specifications.odometer.km', 'specifications.cylinders', 'specifications'])
-                .and.have.lengthOf(1);
-            done();
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql(['a', 'b.c.d'])
+                    .and.containEql(['e', 'f.g.h'])
+                    .and.have.lengthOf(2);
+                done();
+            });
+
+            it('should retrieve keys for an array of one object with an array of objects', (done) => {
+                let testList = [
+                        {
+                            make: 'Nissan',
+                            model: 'GT-R',
+                            trim: 'NISMO',
+                            specifications: [
+                                { mileage: 10 },
+                                { cylinders: '6' }
+                            ]
+                        }
+                    ],
+                    keys = deeks.deepKeysFromList(testList);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql(['make', 'model', 'trim', 'specifications'])
+                    .and.have.lengthOf(1);
+                done();
+            });
+
+            it('should retrieve keys for an array of one object with an array of multi-level objects and a non-object', (done) => {
+                let testList = [
+                        {
+                            make: 'Nissan',
+                            model: 'GT-R',
+                            trim: 'NISMO',
+                            specifications: [
+                                {
+                                    odometer: {
+                                        miles: 10,
+                                        km: 22
+                                    }
+                                },
+                                { cylinders: '6' },
+                                5
+                            ]
+                        }
+                    ],
+                    keys = deeks.deepKeysFromList(testList);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql(['make', 'model', 'trim', 'specifications'])
+                    .and.have.lengthOf(1);
+                done();
+            });
+
+            it('should return the key name for the field with an array value if it contains a non-document value', (done) => {
+                let testList = [
+                        {
+                            make: 'Nissan',
+                            model: 'GT-R',
+                            trim: 'NISMO',
+                            rebates: [
+                                500,
+                                500,
+                                1500
+                            ]
+                        }
+                    ],
+                    keys = deeks.deepKeysFromList(testList);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql(['make', 'model', 'trim', 'rebates'])
+                    .and.have.lengthOf(1);
+                done();
+            });
+        });
+
+        describe('Custom Options', () => {
+            it('[expandArrayObjects] should retrieve keys for an array of one object with an empty array', (done) => {
+                let testList = [
+                        {
+                            make: 'Nissan',
+                            model: 'GT-R',
+                            trim: 'NISMO',
+                            specifications: []
+                        }
+                    ],
+                    options = {
+                        expandArrayObjects: true
+                    },
+                    keys = deeks.deepKeysFromList(testList, options);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql(['make', 'model', 'trim'])
+                    .and.have.lengthOf(1);
+                done();
+            });
+
+            it('[expandArrayObjects] should retrieve keys for an array of one object with an array of non-objects', (done) => {
+                let testList = [
+                        {
+                            make: 'Nissan',
+                            model: 'GT-R',
+                            trim: 'NISMO',
+                            features: ['Insane horsepower', 'Fast acceleration']
+                        }
+                    ],
+                    options = {
+                        expandArrayObjects: true
+                    },
+                    keys = deeks.deepKeysFromList(testList, options);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql(['make', 'model', 'trim', 'features'])
+                    .and.have.lengthOf(1);
+                done();
+            });
+
+            it('[expandArrayObjects] should retrieve keys for an array of one object with an array of objects', (done) => {
+                let testList = [
+                        {
+                            make: 'Nissan',
+                            model: 'GT-R',
+                            trim: 'NISMO',
+                            specifications: [
+                                { mileage: 10 },
+                                { cylinders: '6' }
+                            ]
+                        }
+                    ],
+                    options = {
+                        expandArrayObjects: true
+                    },
+                    keys = deeks.deepKeysFromList(testList, options);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql(['make', 'model', 'trim', 'specifications.mileage', 'specifications.cylinders'])
+                    .and.have.lengthOf(1);
+                done();
+            });
+
+            it('[expandArrayObjects] should retrieve keys for an array of one object with an array of multi-level objects and a non-object', (done) => {
+                let testList = [
+                        {
+                            make: 'Nissan',
+                            model: 'GT-R',
+                            trim: 'NISMO',
+                            specifications: [
+                                {
+                                    odometer: {
+                                        miles: 10,
+                                        km: 22
+                                    }
+                                },
+                                { cylinders: '6' },
+                                5
+                            ]
+                        }
+                    ],
+                    options = {
+                        expandArrayObjects: true
+                    },
+                    keys = deeks.deepKeysFromList(testList, options);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql(['make', 'model', 'trim', 'specifications.odometer.miles', 'specifications.odometer.km', 'specifications.cylinders', 'specifications'])
+                    .and.have.lengthOf(1);
+                done();
+            });
         });
     });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -130,7 +130,8 @@ describe('deeks Module', () => {
                     .and.containEql('make')
                     .and.containEql('model')
                     .and.containEql('trim')
-                    .and.have.lengthOf(3);
+                    .and.containEql('specifications')
+                    .and.have.lengthOf(4);
                 done();
             });
 
@@ -204,6 +205,49 @@ describe('deeks Module', () => {
                     .and.containEql('specifications.cylinders')
                     .and.containEql('specifications')
                     .and.have.lengthOf(6);
+                done();
+            });
+
+            it('[expandArrayObjects, ignoreEmptyArraysWhenExpanding] should retrieve the keys for objects containing an empty array', (done) => {
+                let testObj = {
+                        make: 'Nissan',
+                        model: 'GT-R',
+                        trim: 'NISMO',
+                        specifications: []
+                    },
+                    options = {
+                        expandArrayObjects: true,
+                        ignoreEmptyArraysWhenExpanding: true
+                    },
+                    keys = deeks.deepKeys(testObj, options);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql('make')
+                    .and.containEql('model')
+                    .and.containEql('trim')
+                    .and.have.lengthOf(3);
+                done();
+            });
+
+            it('[expandArrayObjects, ignoreEmptyArraysWhenExpanding] should retrieve the keys for objects containing an array of non-objects', (done) => {
+                let testObj = {
+                        make: 'Nissan',
+                        model: 'GT-R',
+                        trim: 'NISMO',
+                        features: ['Insane horsepower', 'Fast acceleration']
+                    },
+                    options = {
+                        expandArrayObjects: true,
+                        ignoreEmptyArraysWhenExpanding: true
+                    },
+                    keys = deeks.deepKeys(testObj, options);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql('make')
+                    .and.containEql('model')
+                    .and.containEql('trim')
+                    .and.containEql('features')
+                    .and.have.lengthOf(4);
                 done();
             });
         });
@@ -412,7 +456,7 @@ describe('deeks Module', () => {
                     keys = deeks.deepKeysFromList(testList, options);
 
                 keys.should.be.an.instanceOf(Array)
-                    .and.containEql(['make', 'model', 'trim'])
+                    .and.containEql(['make', 'model', 'trim', 'specifications'])
                     .and.have.lengthOf(1);
                 done();
             });
@@ -485,6 +529,48 @@ describe('deeks Module', () => {
 
                 keys.should.be.an.instanceOf(Array)
                     .and.containEql(['make', 'model', 'trim', 'specifications.odometer.miles', 'specifications.odometer.km', 'specifications.cylinders', 'specifications'])
+                    .and.have.lengthOf(1);
+                done();
+            });
+
+            it('[expandArrayObjects, ignoreEmptyArraysWhenExpanding] should retrieve keys for an array of one object with an empty array', (done) => {
+                let testList = [
+                        {
+                            make: 'Nissan',
+                            model: 'GT-R',
+                            trim: 'NISMO',
+                            specifications: []
+                        }
+                    ],
+                    options = {
+                        expandArrayObjects: true,
+                        ignoreEmptyArraysWhenExpanding: true
+                    },
+                    keys = deeks.deepKeysFromList(testList, options);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql(['make', 'model', 'trim'])
+                    .and.have.lengthOf(1);
+                done();
+            });
+
+            it('[expandArrayObjects, ignoreEmptyArraysWhenExpanding] should retrieve keys for an array of one object with an array of non-objects', (done) => {
+                let testList = [
+                        {
+                            make: 'Nissan',
+                            model: 'GT-R',
+                            trim: 'NISMO',
+                            features: ['Insane horsepower', 'Fast acceleration']
+                        }
+                    ],
+                    options = {
+                        expandArrayObjects: true,
+                        ignoreEmptyArraysWhenExpanding: true
+                    },
+                    keys = deeks.deepKeysFromList(testList, options);
+
+                keys.should.be.an.instanceOf(Array)
+                    .and.containEql(['make', 'model', 'trim', 'features'])
                     .and.have.lengthOf(1);
                 done();
             });


### PR DESCRIPTION
* Removes redundant key(s) from the generated key list by improving handling of array cases when expandArrayObjects is set to true.

Fixes #6, needed for: https://github.com/mrodrig/json-2-csv/issues/102