### PR TITLE
Add expandNestedObjects option with default of true & npm audit fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ The array of keys that is returned can then be used with the
 at a specific key path.
 
 Options (optional):
+- expandNestedObjects - `Boolean` (Default: `true`) - Should nested objects appearing in the provided object also be expanded, such asthat keys appearing in those objects are extracted and included in the returned key path list?
+	- Example:
+	```json
+	{
+		"make": "Nissan",
+		"model": "Murano",
+		"year": 2013,
+		"specifications": {
+			"mileage": 7106,
+			"trim": "S AWD"
+		}
+	}
+	```
+	- expandNestedObjects = `false` results in: `['make', 'model', 'year', 'specifications']`
+	- expandNestedObjects = `true` results in: `['make', 'model', 'year', 'specifications.mileage', 'specifications.trim']`
 - expandArrayObjects - `Boolean` (Default: `false`) - Should objects appearing in arrays in the provided 
 object also be expanded, such that keys appearing in those objects are extracted and 
 included in the returned key path list?
@@ -119,6 +134,21 @@ several layers deep in each of the documents. These can also be used with the
 [`doc-path`](https://github.com/mrodrig/doc-path) module.
 
 Options (optional):
+- expandNestedObjects - `Boolean` (Default: `true`) - Should nested objects appearing in the provided object also be expanded, such asthat keys appearing in those objects are extracted and included in the returned key path list?
+	- Example:
+	```json
+	{
+		"make": "Nissan",
+		"model": "Murano",
+		"year": 2013,
+		"specifications": {
+			"mileage": 7106,
+			"trim": "S AWD"
+		}
+	}
+	```
+	- expandNestedObjects = `false` results in: `['make', 'model', 'year', 'specifications']`
+	- expandNestedObjects = `true` results in: `['make', 'model', 'year', 'specifications.mileage', 'specifications.trim']`
 - expandArrayObjects - `Boolean` (Default: `false`) - Should objects appearing in arrays in the provided 
 object also be expanded, such that keys appearing in those objects are extracted and 
 included in the returned key path list?

--- a/package-lock.json
+++ b/package-lock.json
@@ -815,9 +815,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -941,9 +941,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -982,9 +982,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -4108,9 +4108,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -4633,9 +4633,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"

--- a/src/deeks.ts
+++ b/src/deeks.ts
@@ -42,7 +42,7 @@ function generateDeepKeysList(heading: string, data: Record<string, unknown>, op
         const keyName = buildKeyName(heading, escapeNestedDotsIfSpecified(currentKey, options));
 
         // If we have another nested document, recur on the sub-document to retrieve the full key name
-        if (utils.isDocumentToRecurOn(data[currentKey])) {
+        if (options.expandNestedObjects && utils.isDocumentToRecurOn(data[currentKey])) {
             return generateDeepKeysList(keyName, data[currentKey] as Record<string, unknown>, options);
         } else if (options.expandArrayObjects && Array.isArray(data[currentKey])) {
             // If we have a nested array that we need to recur on
@@ -107,6 +107,7 @@ function buildKeyName(upperKeyName: string, currentKeyName: string) {
 
 function mergeOptions(options: DeeksOptions | undefined): DeeksOptions {
     return {
+        expandNestedObjects: true,
         expandArrayObjects: false,
         ignoreEmptyArraysWhenExpanding: false,
         escapeNestedDots: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,9 @@
 'use strict';
 
 export interface DeeksOptions {
+    /** @default true */
+    expandNestedObjects?: boolean,
+
     /** @default false */
     expandArrayObjects?: boolean,
     

--- a/test/index.ts
+++ b/test/index.ts
@@ -150,6 +150,27 @@ describe('deeks Module', () => {
         });
 
         describe('Custom Options', () => {
+            it('[expandNestedObjects] should not expand when not desired', (done) => {
+                const testObj = {
+                        Make: 'Nissan',
+                        Model: 'Murano',
+                        Year: '2013',
+                        Specifications: {
+                            Mileage: '7106',
+                            Trim: 'S AWD'
+                        }
+                    },
+                    options = {
+                        expandNestedObjects: false
+                    },
+                    keys = deepKeys(testObj, options);
+
+                assert.equal(Array.isArray(keys), true);
+                assert.equal(keys.length, 4);
+                assert.deepEqual(keys, ['Make', 'Model', 'Year', 'Specifications']);
+                done();
+            });
+
             it('[expandArrayObjects] options object should be passed to deepKeysFromList when processing an array', (done) => {
                 const testObj = {
                         specifications: [
@@ -608,6 +629,29 @@ describe('deeks Module', () => {
         });
 
         describe('Custom Options', () => {
+            it('[expandNestedObjects] should not expand when not desired', (done) => {
+                const testObj = [
+                        {
+                            Make: 'Nissan',
+                            Model: 'Murano',
+                            Year: '2013',
+                            Specifications: {
+                                Mileage: '7106',
+                                Trim: 'S AWD'
+                            }
+                        }
+                    ],
+                    options = {
+                        expandNestedObjects: false
+                    },
+                    keys = deepKeysFromList(testObj, options);
+
+                assert.equal(Array.isArray(keys), true);
+                assert.equal(keys.length, 1);
+                assert.deepEqual(keys, [ ['Make', 'Model', 'Year', 'Specifications'] ]);
+                done();
+            });
+
             it('[expandArrayObjects] should retrieve keys for an array of one object with an empty array', (done) => {
                 const testList = [
                         {


### PR DESCRIPTION
This option was needed to support the functionality desired in https://github.com/mrodrig/json-2-csv/issues/235

Effectively this adds an option which defaults to `true` which allows the customization of the behavior with regards to whether or not nested objects are expanded and their keys included in order to provide more fine-grained control over the keys returned