### PR TITLE
Add arrayIndexesAsKeys option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,24 @@ The array of keys that is returned can then be used with the
 at a specific key path.
 
 Options (optional):
+- arrayIndexesAsKeys - `Boolean` (Default `false`) - Should array indexes be used as keys in the generated path?
+	- Example:
+	```json
+	[
+		{
+			"list": [
+				{
+					"a": 1
+				},
+				{
+					"a": 2
+				}
+			]
+		}
+	]
+	```
+	- arrayIndexesAsKeys = `false` results in: `['list.a']`
+	- arrayIndexesAsKeys = `true` results in: `['list.0.a', 'list.1.a']`
 - expandNestedObjects - `Boolean` (Default: `true`) - Should nested objects appearing in the provided object also be expanded, such asthat keys appearing in those objects are extracted and included in the returned key path list?
 	- Example:
 	```json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deeks",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deeks",
-      "version": "3.0.2",
+      "version": "3.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deeks",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Retrieve all keys and nested keys from objects and arrays of objects.",
   "main": "lib/deeks.js",
   "types": "lib/deeks.d.ts",

--- a/src/deeks.ts
+++ b/src/deeks.ts
@@ -41,15 +41,22 @@ function generateDeepKeysList(heading: string, data: Record<string, unknown>, op
         // If the given heading is empty, then we set the heading to be the subKey, otherwise set it as a nested heading w/ a dot
         const keyName = buildKeyName(heading, escapeNestedDotsIfSpecified(currentKey, options));
 
+        console.log(`keyName=${keyName}\theading=${heading}\tcurrentKey=${currentKey}`);
+
         // If we have another nested document, recur on the sub-document to retrieve the full key name
-        if (options.expandNestedObjects && utils.isDocumentToRecurOn(data[currentKey])) {
+        if (options.expandNestedObjects && utils.isDocumentToRecurOn(data[currentKey]) || (options.arrayIndexesAsKeys && Array.isArray(data[currentKey]) && (data[currentKey] as any).length)) {
+            console.log('  case 1');
             return generateDeepKeysList(keyName, data[currentKey] as Record<string, unknown>, options);
         } else if (options.expandArrayObjects && Array.isArray(data[currentKey])) {
+            console.log('  case 2');
+            console.log('    Object.keys', Object.keys(data[currentKey] as any));
             // If we have a nested array that we need to recur on
             return processArrayKeys(data[currentKey] as object[], keyName, options);
         } else if (options.ignoreEmptyArrays && Array.isArray(data[currentKey]) && !(data[currentKey] as unknown[]).length) {
+            console.log('  case 3');
             return [];
         }
+        console.log('  default');
         // Otherwise return this key name since we don't have a sub document
         return keyName;
     });
@@ -107,6 +114,7 @@ function buildKeyName(upperKeyName: string, currentKeyName: string) {
 
 function mergeOptions(options: DeeksOptions | undefined): DeeksOptions {
     return {
+        arrayIndexesAsKeys: false,
         expandNestedObjects: true,
         expandArrayObjects: false,
         ignoreEmptyArraysWhenExpanding: false,

--- a/src/deeks.ts
+++ b/src/deeks.ts
@@ -41,22 +41,15 @@ function generateDeepKeysList(heading: string, data: Record<string, unknown>, op
         // If the given heading is empty, then we set the heading to be the subKey, otherwise set it as a nested heading w/ a dot
         const keyName = buildKeyName(heading, escapeNestedDotsIfSpecified(currentKey, options));
 
-        console.log(`keyName=${keyName}\theading=${heading}\tcurrentKey=${currentKey}`);
-
         // If we have another nested document, recur on the sub-document to retrieve the full key name
-        if (options.expandNestedObjects && utils.isDocumentToRecurOn(data[currentKey]) || (options.arrayIndexesAsKeys && Array.isArray(data[currentKey]) && (data[currentKey] as any).length)) {
-            console.log('  case 1');
+        if (options.expandNestedObjects && utils.isDocumentToRecurOn(data[currentKey]) || (options.arrayIndexesAsKeys && Array.isArray(data[currentKey]) && (data[currentKey] as unknown[]).length)) {
             return generateDeepKeysList(keyName, data[currentKey] as Record<string, unknown>, options);
         } else if (options.expandArrayObjects && Array.isArray(data[currentKey])) {
-            console.log('  case 2');
-            console.log('    Object.keys', Object.keys(data[currentKey] as any));
             // If we have a nested array that we need to recur on
             return processArrayKeys(data[currentKey] as object[], keyName, options);
         } else if (options.ignoreEmptyArrays && Array.isArray(data[currentKey]) && !(data[currentKey] as unknown[]).length) {
-            console.log('  case 3');
             return [];
         }
-        console.log('  default');
         // Otherwise return this key name since we don't have a sub document
         return keyName;
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,9 @@
 'use strict';
 
 export interface DeeksOptions {
+    /** @default false */
+    arrayIndexesAsKeys?: boolean,
+
     /** @default true */
     expandNestedObjects?: boolean,
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -401,6 +401,25 @@ describe('deeks Module', () => {
                 assert.deepEqual(keys, ['a.c.f']);
                 done();
             });
+
+            it('[arrayIndexesAsKeys] should properly use array indexes as keys when specified', (done) => {
+                const testObj = {
+                        list: [{
+                            a: 1
+                        }, {
+                            a: 2
+                        }]
+                    },
+                    options = {
+                        arrayIndexesAsKeys: true
+                    },
+                    keys = deepKeys(testObj, options);
+
+                assert.equal(Array.isArray(keys), true);
+                assert.equal(keys.length, 2);
+                assert.deepEqual(keys, ['list.0.a', 'list.1.a']);
+                done();
+            });
         });
     });
 
@@ -881,6 +900,25 @@ describe('deeks Module', () => {
                 assert.equal(Array.isArray(keys), true);
                 assert.equal(keys.length, 1);
                 assert.deepEqual(keys, [ ['a.c.f'] ]);
+                done();
+            });
+
+            it('[arrayIndexesAsKeys] should properly use array indexes as keys when specified', (done) => {
+                const testList = [{
+                        list: [{
+                            a: 1
+                        }, {
+                            a: 2
+                        }]
+                    }],
+                    options = {
+                        arrayIndexesAsKeys: true
+                    },
+                    keys = deepKeysFromList(testList, options);
+
+                assert.equal(Array.isArray(keys), true);
+                assert.equal(keys.length, 1);
+                assert.deepEqual(keys, [ ['list.0.a', 'list.1.a'] ]);
                 done();
             });
         });


### PR DESCRIPTION
Adds new feature to help get a more representative path of object keys inside arrays to support desired behavior in https://github.com/mrodrig/json-2-csv/issues/207